### PR TITLE
Add presale safeguards and tighten token ops

### DIFF
--- a/ZIMXTokenFINALDEPLOY.sol
+++ b/ZIMXTokenFINALDEPLOY.sol
@@ -93,11 +93,15 @@ contract ZIMXTokenFINALDEPLOY is ERC20, ERC20Burnable, Pausable, ERC20Permit {
      * @param newGovernance Address of the new governance multisig.
      */
     function transferGovernance(address newGovernance) external onlyGovernance {
-        require(newGovernance != address(0), "GOV_ZERO");
-        require(newGovernance != governance, "ALREADY_GOV");
-        require(pendingGovernance == address(0), "PENDING_GOV");
-        pendingGovernance = newGovernance;
-        emit GovernanceTransferStarted(governance, newGovernance);
+        _initiateGovernanceTransfer(newGovernance);
+    }
+
+    /**
+     * @notice Initiates governance transfer using the ownership naming convention for compatibility.
+     * @param newOwner Address of the contract set to receive governance powers.
+     */
+    function transferOwnership(address newOwner) external onlyGovernance {
+        _initiateGovernanceTransfer(newOwner);
     }
 
     /**
@@ -224,5 +228,14 @@ contract ZIMXTokenFINALDEPLOY is ERC20, ERC20Burnable, Pausable, ERC20Permit {
      */
     function onChainPromiseCount() external view returns (uint256) {
         return _promises.length;
+    }
+
+    function _initiateGovernanceTransfer(address newGovernance) internal {
+        require(newGovernance != address(0), "GOV_ZERO");
+        require(newGovernance.code.length > 0, "OWNER_NOT_CONTRACT");
+        require(newGovernance != governance, "ALREADY_GOV");
+        require(pendingGovernance == address(0), "PENDING_GOV");
+        pendingGovernance = newGovernance;
+        emit GovernanceTransferStarted(governance, newGovernance);
     }
 }


### PR DESCRIPTION
## Summary
- gate presale finalization on vault update cooldown, expected proceeds, and add dust sweeping and revert-only ether receiver/fallback
- add governance configuration for expected proceeds, vault timestamp tracking, and emit new oversight events
- enforce governance transfers to contract wallets, add treasury sealing fuse, and bolster vesting release CEI plus voucher escrow allowance tracking

## Testing
- `solc --base-path . --include-path node_modules --allow-paths . ZIMXPresale.sol ZIMXTokenFINALDEPLOY.sol ZIMXVesting.sol ZIMXVoucher.sol` *(fails: `solc` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2695d06c832a86e54b48d6c7ae82