### PR TITLE
Increase ZIMX presale allocation to 10%

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ZIMX is the fixed-supply governance and utility token powering presale, vesting 
 
 ## Contracts
 - **ZIMXTokenFINALDEPLOY.sol** – 1B supply governance/utility token
-- **ZIMXPresale.sol** – capped presale with hard cap, buyer limits, reserve split
+- **ZIMXPresale.sol** – capped presale (100M ZIMX) with buyer limits, reserve split
 - **ZIMXVesting.sol** – linear vesting with cliffs
 - **ZIMXVoucher.sol** – voucher issuance and redemption
 
@@ -18,6 +18,6 @@ ZIMX is the fixed-supply governance and utility token powering presale, vesting 
 ## Features
 - Immutable supply (1,000,000,000 ZIMX)
 - Governance functions locked until 2027
-- Presale capped at 50M ZIMX with enforced reserve split
+- Presale capped at 100M ZIMX raising £10m at £0.10 with enforced reserve split
 - Transparent events for allocations, purchases, vesting and vouchers
 - Ownership through multisig + timelock

--- a/ZIMXPresale.sol
+++ b/ZIMXPresale.sol
@@ -22,8 +22,10 @@ contract ZIMXPresale is Pausable, ReentrancyGuard {
     /// @notice Timestamp when governance-controlled configuration becomes available (2027-01-01 UTC).
     uint256 public constant GOVERNANCE_ENABLE_TS = 1_798_761_600;
 
-    /// @notice Total number of tokens that can be sold via the presale (6 decimals).
-    uint256 public constant HARD_CAP = 50_000_000 * 10 ** 6;
+    /// @notice Total number of tokens that can be sold via the presale (6 decimals) – 10% of supply.
+    uint256 public constant HARD_CAP = 100_000_000 * 10 ** 6;
+    /// @notice Target amount to raise across all assets normalised to 18 decimals (£10m at £0.10 per token).
+    uint256 public constant PRESALE_RAISE_TARGET = 10_000_000 * 10 ** 18;
 
     /// @notice Address responsible for privileged governance actions (intended multisig).
     address public governance;
@@ -38,7 +40,7 @@ contract ZIMXPresale is Pausable, ReentrancyGuard {
     uint8 public immutable stableDecimals;
 
     /// @notice Maximum tokens a single buyer can acquire (6 decimals).
-    uint256 public buyerMax = 500_000 * 10 ** 6;
+    uint256 public buyerMax = 1_000_000 * 10 ** 6;
     /// @notice Portion of proceeds sent to the reserve vault (basis points).
     uint16 public reserveBps = 5000;
 
@@ -228,6 +230,8 @@ contract ZIMXPresale is Pausable, ReentrancyGuard {
         if (reserveVault_ != address(0) && opsTreasury_ != address(0)) {
             _setVaults(reserveVault_, opsTreasury_);
         }
+
+        expectedTotal = PRESALE_RAISE_TARGET;
     }
 
     /// @notice Current token rate when purchasing with the stablecoin (tokens per one stable unit).

--- a/ZIMXVesting.sol
+++ b/ZIMXVesting.sol
@@ -15,6 +15,9 @@ contract ZIMXVesting is ReentrancyGuard {
     /// @notice Timestamp when governance managed operations become available (2027-01-01 UTC).
     uint256 public constant GOVERNANCE_ENABLE_TS = 1_798_761_600;
 
+    /// @notice Mirror of the presale allocation for analytics (10% of total supply at 6 decimals).
+    uint256 public constant PRESALE_ALLOCATION = 100_000_000 * 10 ** 6;
+
     /// @notice Token being vested.
     IERC20 public immutable token;
     /// @notice Global vesting start timestamp.

--- a/ZIMXVoucher.sol
+++ b/ZIMXVoucher.sol
@@ -18,6 +18,9 @@ contract ZIMXVoucher is ERC721, ReentrancyGuard {
     /// @notice Timestamp when governance managed voucher features become available (2027-01-01 UTC).
     uint256 public constant GOVERNANCE_ENABLE_TS = 1_798_761_600;
 
+    /// @notice Mirror of the presale allocation for analytics (10% of total supply at 6 decimals).
+    uint256 public constant PRESALE_ALLOCATION = 100_000_000 * 10 ** 6;
+
     /// @notice ZIMX token that vouchers can be redeemed for.
     IERC20 public immutable token;
     /// @notice Governance address managing voucher issuance.


### PR DESCRIPTION
## Summary
- raise the presale hard cap to 100M ZIMX, seed the £10m target in contract state, and scale the buyer limit accordingly
- expose the updated presale allocation constant in vesting and voucher contracts for downstream analytics parity
- refresh README messaging to describe the expanded presale allocation and raise target

## Testing
- not run (contracts only)


------
https://chatgpt.com/codex/tasks/task_e_68d644a18d3c832a9d63701f5667d658