### PR TITLE
Add note about excluding ZIMXVoucher from current scope

### DIFF
--- a/ZIMXVoucher.sol
+++ b/ZIMXVoucher.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/**
+ * @notice This contract is not part of the current deployment scope, is retained for
+ * potential future use, and should be excluded from current testing and build work.
+ */
+
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";


### PR DESCRIPTION
## Summary
- add a prominent comment explaining ZIMXVoucher is out of current deployment scope
- instruct maintainers to exclude the contract from present testing and build processes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d982e5eaac832aa9a0fa95882b916c